### PR TITLE
Support for Type Aliases

### DIFF
--- a/Binaries/Sourcery.artifactbundle/sourcery-2.1.7/Templates/Target/Factory.stencil
+++ b/Binaries/Sourcery.artifactbundle/sourcery-2.1.7/Templates/Target/Factory.stencil
@@ -13,6 +13,14 @@ import {{ import }}
     {% endfor %}
 {% endmacro %}
 
+{% macro searchAutoResolve specificTypes -%}
+    {%- for resolvableType in specificTypes %}
+        {%- for resolvableAnnotation, objects in resolvableType.attributes where resolvableAnnotation == "Singleton" or resolvableAnnotation == "Alias" %}
+            {%- if types.based.AutoSetup|count == 1 and parameter.asSource|contains:resolvableType.name or objects[0].description|contains:".self" and objects[0].description|contains:parameter.typeName %} = {{ types.based.AutoSetup.first.name }}.resolve(){% endif -%}
+        {% endfor -%}
+    {% endfor -%}
+{%- endmacro %}
+
 {% macro initParameters parameters resolver %}
     {% for parameter in parameters %}
         {% if parameter|annotated:"configurable" %}
@@ -52,15 +60,9 @@ extension {{ type.name }} {
     // Single target project or composition root
     public static func create(
         {% for parameter in initializer.parameters %}
-            {{ parameter.name }}: {{ parameter.typeName }}
-            {%- for resolvableType in types.all %}
-                {%- for resolvableAnnotation, objects in resolvableType.attributes where resolvableAnnotation == "Singleton" %}
-                    {%- if types.based.AutoSetup|count == 1 and parameter.asSource|contains:resolvableType.name or objects[0].description|contains:".self" and objects[0].description|contains:parameter.typeName %} = {{ types.based.AutoSetup.first.name }}.resolve(){% endif -%}
-                {% endfor -%}
-            {% endfor -%}
-            {{ ", " if not forloop.last }}
+        {{ parameter.name }}: {{ parameter.typeName }}{% call searchAutoResolve types.all %}{% call searchAutoResolve types.protocols %}{{ ", " if not forloop.last }}
         {% endfor %}
-        ) -> {{ type.name }} {
+    ) -> {{ type.name }} {
         {{ type.name }}({%- for parameter in initializer.parameters %}{{ parameter.name}}: {{ parameter.name}}{{ ", " if not forloop.last }}{% endfor -%})
     }
     {% else %}

--- a/Binaries/Sourcery.artifactbundle/sourcery-2.1.7/Templates/Target/Register.stencil
+++ b/Binaries/Sourcery.artifactbundle/sourcery-2.1.7/Templates/Target/Register.stencil
@@ -9,6 +9,20 @@ import {{ import }}
 {% endfor %}
 {% endmacro %}
 
+{% macro registerAlias baseType -%}
+    {% for protocol in types.protocols %}
+        {% for attribute, objects in protocol.attributes %}
+            {% if attribute == "Alias" %}
+                {% set baseTypes %}{{ objects[0].description|replace:" ",""|replace:"[",""|replace:"]",""|replace:"@Alias(for:",""|replace:")",""|replace:".self","" }}{% endset %}
+                {% if baseTypes|contains:baseType %}
+        try container.register(alias: {{protocol.name}}.self, for: Self.self)
+                {% endif %}
+                
+            {% endif %}
+        {% endfor %}
+    {% endfor %}
+{%- endmacro %}
+
 {% macro hasTypeInformation description -%}
     {%- if description|replace:"@Singleton",""|replace:"(",""|replace:")",""|replace:"autoRegister:",""|replace:"isEager:",""|replace:"true",""|replace:"false",""|replace:" ","" != "" -%}true{%- else -%}false{%- endif -%}
 {%- endmacro %}
@@ -98,11 +112,20 @@ extension {{ type.name }} {
         try container.register({% call parseTypes additionalTypeInfo %}, isEager: isEager) {
         {% call generateInitializer initializer %}
         }
+        
+        {% set additionalTypes %}{% call parseTypes additionalTypeInfo %}{% endset %}
+        
+        {% for additionalType in additionalTypes|replace:" ",""|replace:".self",""|replace:"[",""|replace:"]",""|split: "," %}
+            {% call registerAlias additionalType %}
+        {% endfor %}
+        
         {% else %}
         try container.register(isEager: isEager) {
         {% call generateInitializer initializer %}
         }
         {% endif %}
+        
+        {% call registerAlias type.name %}
     }
         {% break %}
     {% endfor %}
@@ -116,6 +139,7 @@ extension {{ type.name }} {
         {% else %}
         try container.register(isEager: isEager) { {{ type.name }}() }
         {% endif %}
+        {% call registerAlias type.name %}
     }
     {% endif %}
 }

--- a/Demo/SwiftDependencyContainerDemo/SwiftDependencyContainerDemo/Dependencies/Analytics.swift
+++ b/Demo/SwiftDependencyContainerDemo/SwiftDependencyContainerDemo/Dependencies/Analytics.swift
@@ -5,14 +5,13 @@ protocol ClockTracking {
     func clockStarted()
 }
 
+@Alias(for: Analytics.self)
 protocol CounterTracking {
     func counterCreated()
 }
 
-protocol Tracking: ClockTracking, CounterTracking {}
-
-@Singleton(ClockTracking.self, CounterTracking.self)
-final class Analytics: Tracking {
+@Singleton(ClockTracking.self)
+final class Analytics: ClockTracking, CounterTracking {
     init(tracker: AnalyticsTracker) {}
     
     func clockStarted() {

--- a/Sources/SwiftDependencyContainer/DependencyContainer.swift
+++ b/Sources/SwiftDependencyContainer/DependencyContainer.swift
@@ -19,6 +19,7 @@ public final class DependencyContainer {
     public enum RegisterError: Error {
         case missingKey
         case aliasAlreadyTaken
+        case aliasSourceMissing
         case alreadyBootstrapped(keys: String)
     }
     
@@ -45,6 +46,10 @@ public final class DependencyContainer {
         var sourceKey = keyValue(for: type)
         while let source = keysAliases[sourceKey] ?? hiddenAbstractions[sourceKey] {
             sourceKey = source
+        }
+        
+        if bootstrapped && !dependencies.keys.contains(sourceKey) {
+            throw RegisterError.aliasSourceMissing
         }
         
         register(alias: aliasKey, for: sourceKey)

--- a/Sources/SwiftDependencyContainer/DependencyContainer.swift
+++ b/Sources/SwiftDependencyContainer/DependencyContainer.swift
@@ -39,7 +39,14 @@ public final class DependencyContainer {
         guard !isKnwonAlias || override else {
             throw RegisterError.aliasAlreadyTaken
         }
-        register(alias: aliasKey, for: keyValue(for: type))
+        
+        // resolve all aliases until root
+        var sourceKey = keyValue(for: type)
+        while let source = keysAliases[sourceKey] {
+            sourceKey = source
+        }
+        
+        register(alias: aliasKey, for: sourceKey)
     }
     
     public func register<T, U>(_ type: U.Type, isEager: Bool = false, bootstrap: @escaping () -> T) throws {

--- a/Sources/SwiftDependencyContainer/Macros.swift
+++ b/Sources/SwiftDependencyContainer/Macros.swift
@@ -18,5 +18,17 @@ public macro Singleton(
 ///
 ///
 @attached(peer, names: named(Factory))
-public macro Factory() =
-#externalMacro(module: "SwiftDependencyContainerMacroPlugin", type: "FactoryMacro")
+public macro Factory() = #externalMacro(module: "SwiftDependencyContainerMacroPlugin", type: "FactoryMacro")
+
+/// Declares a function that can be used to register a type alias.
+///
+/// A `@Alias` autogenerates the code to resolve a dependency using an alias type.
+///
+///
+/// - Parameters:
+///   - types: Specifies the types that the instance will be registered with.
+///
+@attached(peer, names: named(Alias))
+public macro Alias(
+    for types: Any.Type...
+) = #externalMacro(module: "SwiftDependencyContainerMacroPlugin", type: "AliasMacro")

--- a/Sources/SwiftDependencyContainerMacroPlugin/AliasMacro.swift
+++ b/Sources/SwiftDependencyContainerMacroPlugin/AliasMacro.swift
@@ -1,8 +1,9 @@
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
-import SwiftSyntax
+import Foundation
 
-public struct FactoryMacro: PeerMacro {
+public struct AliasMacro: PeerMacro {
     public static func expansion(
         of node: AttributeSyntax,
         providingPeersOf declaration: some DeclSyntaxProtocol,
@@ -12,6 +13,6 @@ public struct FactoryMacro: PeerMacro {
          Code generation is still done using Sourcery.
          Plan is to migrate functionality over to Swift macros over time.
          */
-        return []
+        []
     }
 }

--- a/Sources/SwiftDependencyContainerMacroPlugin/SingletonMacro.swift
+++ b/Sources/SwiftDependencyContainerMacroPlugin/SingletonMacro.swift
@@ -1,7 +1,6 @@
 import SwiftSyntax
-import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
-import Foundation
+import SwiftSyntax
 
 public struct SingletonMacro: PeerMacro {
     public static func expansion(

--- a/Sources/SwiftDependencyContainerMacroPlugin/SwiftDependencyContainerMacroPlugin.swift
+++ b/Sources/SwiftDependencyContainerMacroPlugin/SwiftDependencyContainerMacroPlugin.swift
@@ -6,6 +6,7 @@ import Foundation
 struct SwiftDependencyContainerMacroPlugin: CompilerPlugin {
     let providingMacros: [Macro.Type] = [
         SingletonMacro.self,
-        FactoryMacro.self
+        FactoryMacro.self,
+        AliasMacro.self
     ]
 }

--- a/Tests/SwiftDependencyContainerMacroPluginTests/SwiftDependencyContainerMacroPluginTests.swift
+++ b/Tests/SwiftDependencyContainerMacroPluginTests/SwiftDependencyContainerMacroPluginTests.swift
@@ -38,4 +38,20 @@ final class SwiftDependencyContainerMacroPluginTests: XCTestCase {
         throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
+    
+    func test_emptyAliasMacro() throws {
+        #if canImport(SwiftDependencyContainerMacroPlugin)
+        assertMacroExpansion("""
+            @Alias
+            class MyClass {}
+            """,
+            expandedSource: """
+            class MyClass {}
+            """,
+            macros: ["Alias": AliasMacro.self]
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
 }

--- a/Tests/SwiftDependencyContainerTests/DependencyContainerTests.swift
+++ b/Tests/SwiftDependencyContainerTests/DependencyContainerTests.swift
@@ -256,6 +256,14 @@ class DependencyContainerTests: XCTestCase {
         XCTAssertTrue(resolved2 === resolved3)
     }
     
+    func test_registerAliasForAbstractedType() throws {
+        try sut.register(BaseSingleton.self) { SingletonImpl1() }
+        
+        try sut.register(alias: Singleton1.self, for: SingletonImpl1.self)
+        
+        let _: Singleton1 = try sut.resolve()
+    }
+    
     func test_registerAliasForDifferentAlias() throws {
         try sut.register { SingletonImpl1() }
         

--- a/Tests/SwiftDependencyContainerTests/DependencyContainerTests.swift
+++ b/Tests/SwiftDependencyContainerTests/DependencyContainerTests.swift
@@ -249,6 +249,28 @@ class DependencyContainerTests: XCTestCase {
         } catch {
             // expected
         }
+        
+        try sut.register(alias: SingletonImpl1.self, for: BaseSingleton.self)
+        
+        let resolved3: SingletonImpl1 = try sut.resolve()
+        XCTAssertTrue(resolved2 === resolved3)
+    }
+    
+    func test_registerAliasForDifferentAlias() throws {
+        try sut.register { SingletonImpl1() }
+        
+        let singleton: SingletonImpl1 = try sut.resolve()
+        
+        try sut.register(alias: BaseSingleton.self, for: type(of: singleton))
+        
+        let resolved1: BaseSingleton = try sut.resolve()
+        
+        try sut.register(alias: Singleton1.self, for: BaseSingleton.self)
+        
+        let resolved2: Singleton1 = try sut.resolve()
+        
+        XCTAssertTrue(resolved1 === singleton)
+        XCTAssertTrue(resolved2 === singleton)
     }
     
     func test_multipleTypeInfoWithResolverContext() throws {

--- a/Tests/SwiftDependencyContainerTests/DependencyContainerTests.swift
+++ b/Tests/SwiftDependencyContainerTests/DependencyContainerTests.swift
@@ -264,6 +264,24 @@ class DependencyContainerTests: XCTestCase {
         let _: Singleton1 = try sut.resolve()
     }
     
+    func test_tryToRegisterAliasForUnknownDependencyInBootstrappedContainer() throws {
+        try sut.register { SingletonImpl1() }
+        
+        try sut.bootstrap()
+        
+        do {
+            try sut.register(alias: Singleton1.self, for: BaseSingleton.self)
+            
+            XCTFail("It shouldn't be possible to register an alias for an unknown source after container is bootstrapped.")
+        } catch {
+            if case .aliasSourceMissing = error as? DependencyContainer.RegisterError {
+                // expected
+            } else {
+                XCTFail("Unknown error: \(error)")
+            }
+        }
+    }
+    
     func test_registerAliasForDifferentAlias() throws {
         try sut.register { SingletonImpl1() }
         
@@ -273,6 +291,7 @@ class DependencyContainerTests: XCTestCase {
         
         let resolved1: BaseSingleton = try sut.resolve()
         
+        // register another alias after container was automatically bootstrapped
         try sut.register(alias: Singleton1.self, for: BaseSingleton.self)
         
         let resolved2: Singleton1 = try sut.resolve()


### PR DESCRIPTION
Add support to register type aliases for already registered dependencies, even after bootstrapping.

`func register<T, U>(alias: U.Type, for type: T.Type, override: Bool = false) throws`

Useful to abstract dependencies especially for projects with multiple targets, where the registered dependency and the abstraction don't live in the same target.

```swift
@Alias(for: RegisteredDependency.self)
protocol MyAbstraction {
    func relevantForMe()
}
```

Demo project has been updated to showcase the new feature.